### PR TITLE
added chunk

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -27,7 +27,7 @@ end
 function Base.cat(ts::Tensor{T,N}...; dims = 1) where {T,N}
   ptr = Ref(Ptr{Cvoid}())
   ts_arr = [i.ptr for i in ts]
-  atg_cat(ptr, ts_arr, length(ts_arr), dims - 1)
+  atg_cat(ptr, ts_arr, length(ts_arr), N - dims)
   Tensor{T,N}(ptr[], on(ts[1]))
 end
 
@@ -52,7 +52,7 @@ end
 function _softmax(input::Tensor{T,N}, dims = 1, dtype = options[T]) where {T,N}
   ptr = Ref(Ptr{Cvoid}())
 
-  atg_softmax(ptr, input.ptr, dims - 1, dtype)
+  atg_softmax(ptr, input.ptr, N - dims, dtype)
   Tensor{T,N}(ptr[], on(input))
 end
 
@@ -108,4 +108,10 @@ function _maxpool_with_inds(t::Tensor{T,M}, pdims::PoolDims{N,K,S,P,D};
   )
 
   Tensor{T,M}(ptr[1], on(t)), Tensor{T,M}(ptr[2], on(t))
+end
+
+function _chunk(t::Tensor{T,N}, chunks=2, dims=1) where {T,N}
+  ts = [Ptr{Cvoid}() for _ in 1:chunks]
+  atg_chunk(ts, t.ptr, chunks, N - dims)
+  [Tensor{T,N}(ts[i], on(t)) for i in 1:chunks]
 end


### PR DESCRIPTION
I added the `_chunk` method which splits up the input tensor in equally sized chunks, along a given dimension. Default params are 2 chunks, along the first dimension.

Resolves #7 

**Example**
```julia
using Torch

ip = rand(Float32, 10, 10, 16, 2) # (10x10x16x2) in (WxHxCxN) order
tip = tensor(ip, dev = 0)
chunks = Torch._chunk(tip, 2, 3)
top = cat(chunks..., dims=3)
```

Where `tip` is a (10x10x16x2) tensor, `chunks` is a vector of two (10x10x8x2) tensors after splitting along the third dimension, and `top` again has the same shape as `tip` after concatenating over the third dimension.